### PR TITLE
Error handling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-modules
 examples
 scripts
 karma.conf.js

--- a/README.md
+++ b/README.md
@@ -120,10 +120,16 @@ var routes = (
   </Route>
 );
 
-// same signature as Router.run
+// Same signature as Router.run, except for the 4th argument which is the
+// aggregate promise of all asyncProp loaders. You can use this to handle
+// loading errors.
 var { HistoryLocation } = require('react-router');
-run(routes, HistoryLocation, (Handler, state, asyncProps) => {
+run(routes, HistoryLocation, (Handler, state, asyncProps, loader) => {
   React.render(<Handler/>, document.body);
+
+  loader.then(null, function(error) {
+    // handle error
+  });
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ WIP
 This is a work in progress, we're going to try it out in one of our apps
 @instructure, see how it goes.
 
+**This library assumes `Promise` is available as a global.**
+
 Usage
 -----
 

--- a/modules/__tests__/index.test.js
+++ b/modules/__tests__/index.test.js
@@ -2,7 +2,6 @@ console.log(Date.now());
 var React = require('react');
 var Router = require('react-router');
 var expect = require('expect');
-var Promise = require('when').Promise;
 var { Route } = Router;
 var { EventEmitter } = require('events');
 

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,19 +1,36 @@
-var Promise = require('when').Promise;
-var keys = require('when/keys');
 var React = require('react');
 var assign = require('react/lib/Object.assign');
 var Router = require('react-router');
-var { RouteHandlerMixin } = Router;
 var warning = require('react/lib/warning');
+var { RouteHandlerMixin } = Router;
 
 var getAsyncProps = (components, info) => {
-  return Promise.all(components.map((component) => {
-    var asyncProps = component.asyncProps || {};
-    return keys.all(Object.keys(asyncProps).reduce((promises, propName) => {
-      promises[propName] = asyncProps[propName].load(info);
-      return promises;
-    }, {}));
-  }));
+  var loaders = components.reduce(function(loaders, component) {
+    if (component.hasOwnProperty('asyncProps')) {
+      Object.keys(component.asyncProps).forEach(function(propName) {
+        loaders.push(component.asyncProps[propName].load(info));
+      });
+    }
+
+    return loaders;
+  }, []);
+
+  return Promise.all(loaders).then(function(result) {
+    var cursor = 0;
+
+    return components.reduce(function(propSet, component) {
+      var props = {};
+
+      if (component.hasOwnProperty('asyncProps')) {
+        props = Object.keys(component.asyncProps).reduce(function(props, propName) {
+          props[propName] = result[cursor++];
+          return props;
+        }, {});
+      }
+
+      return propSet.concat(props);
+    }, []);
+  });
 };
 
 var runHooks = (hook, handler, asyncState) => {
@@ -136,7 +153,7 @@ var runRouter = (router, callback) => {
     getAsyncProps(handlers, routerState).then((props) => {
       setState({ props });
       callback(Root, routerState, state.props);
-    }).done();
+    });
   };
 
   router.run((Handler, routerState) => {
@@ -163,4 +180,3 @@ module.exports = {
   getAsyncProps,
   RouteHandler
 };
-

--- a/modules/index.js
+++ b/modules/index.js
@@ -5,9 +5,9 @@ var warning = require('react/lib/warning');
 var { RouteHandlerMixin } = Router;
 
 var getAsyncProps = (components, info) => {
-  var loaders = components.reduce(function(loaders, component) {
+  var loaders = components.reduce((loaders, component) => {
     if (component.hasOwnProperty('asyncProps')) {
-      Object.keys(component.asyncProps).forEach(function(propName) {
+      Object.keys(component.asyncProps).forEach((propName) => {
         loaders.push(component.asyncProps[propName].load(info));
       });
     }
@@ -15,14 +15,14 @@ var getAsyncProps = (components, info) => {
     return loaders;
   }, []);
 
-  return Promise.all(loaders).then(function(result) {
+  return Promise.all(loaders).then((result) => {
     var cursor = 0;
 
-    return components.reduce(function(propSet, component) {
+    return components.reduce((propSet, component) => {
       var props = {};
 
       if (component.hasOwnProperty('asyncProps')) {
-        props = Object.keys(component.asyncProps).reduce(function(props, propName) {
+        props = Object.keys(component.asyncProps).reduce((props, propName) => {
           props[propName] = result[cursor++];
           return props;
         }, {});
@@ -150,10 +150,12 @@ var runRouter = (router, callback) => {
   var run = () => {
     var { routerState } = state;
     var handlers = routerState.routes.map(route => route.handler);
-    getAsyncProps(handlers, routerState).then((props) => {
+    var loader = getAsyncProps(handlers, routerState);
+    var notify = () => { callback(Root, routerState, state.props, loader); };
+
+    loader.then((props) => {
       setState({ props });
-      callback(Root, routerState, state.props);
-    });
+    }).then(notify, notify);
   };
 
   router.run((Handler, routerState) => {

--- a/modules/index.js
+++ b/modules/index.js
@@ -50,14 +50,34 @@ var RouteHandler = React.createClass({
   componentDidMount () {
     var route = this.context.getRouteAtDepth(this.getRouteDepth());
     // TODO: do we really need this? surfacing in ember migration app
-    if (route && route.handler)
+    if (route && route.handler) {
       runHooks('setup', route.handler, this.context.asyncPropsState);
+      this.lastHandler = route.handler;
+    }
+  },
+
+  componentDidUpdate() {
+    var route = this.context.getRouteAtDepth(this.getRouteDepth());
+    var lastHandler = this.lastHandler;
+    var currHandler;
+
+    if (route && route.handler) {
+      currHandler = route.handler;
+
+      if (lastHandler !== currHandler) {
+        runHooks('teardown', lastHandler, this.context.asyncPropsState);
+        runHooks('setup', currHandler, this.context.asyncPropsState);
+        this.lastHandler = currHandler;
+      }
+    }
   },
 
   componentWillUnmount () {
     var route = this.context.getRouteAtDepth(this.getRouteDepth());
     if (route && route.handler)
       runHooks('teardown', route.handler, this.context.asyncPropsState);
+
+    this.lastHandler = null;
   },
 
   render () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-async-props",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -25,9 +25,6 @@
     "react-tools": "0.12.2",
     "rf-release": "0.4.0",
     "webpack": "1.5.3"
-  },
-  "dependencies": {
-    "when": "^3.7.2"
   },
   "peerDependencies": {
     "react": "0.12.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-async-props",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-async-props",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
I don't really like it, because we're receiving the promise as the 4th argument, but by the time the callback is invoked, the promise has already been fulfilled...

It looks bad from the caller's code:

```javascript
runRouter(router, (Handler, state, _, loader) => {
  React.render(<Handler />, document.body);
  loader.then(null, function(error) {
    // woot, but we just rendered the Handler above? >.<
  });
});
```

It would probably make much more sense to just pass in the error variable as the 1st one, or accept an onError callback just like we're accepting an onReady callback.

```javascript
runRouter(router, (err, Handler, state, _, loader) => {
  if (err) {
    console.error(err);
  }
  else {
    React.render(<Handler />, document.body);
  }
});
```

or

```javascript
runRouter(router, (Handler, state, _, loader) => {
  React.render(<Handler />, document.body);
}, (err) => {
  console.error(err);
});
```

I like those two just the same, no preference. What do u think ?